### PR TITLE
Security: add server-side permission checks to NPC packet handlers

### DIFF
--- a/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcJump.java
+++ b/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcJump.java
@@ -11,6 +11,9 @@ public class ServerHandlerNpcJump extends ServerMessageHandler<PacketNpcJump>
     @Override
     public void run(EntityPlayerMP player, PacketNpcJump message)
     {
+        if (player.getRidingEntity() == null || player.getRidingEntity().getEntityId() != message.entityId) {
+            return;
+        }
         Entity npc = player.world.getEntityByID(message.entityId);
 
         if (npc instanceof EntityNpc)

--- a/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcList.java
+++ b/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcList.java
@@ -5,6 +5,7 @@ import mchorse.mappet.api.npcs.Npc;
 import mchorse.mappet.network.Dispatcher;
 import mchorse.mappet.network.common.npc.PacketNpcList;
 import mchorse.mclib.network.ServerMessageHandler;
+import mchorse.mclib.utils.OpHelper;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import java.util.Collections;
@@ -14,8 +15,7 @@ public class ServerHandlerNpcList extends ServerMessageHandler<PacketNpcList>
     @Override
     public void run(EntityPlayerMP player, PacketNpcList message)
     {
-        if (message.npcs.isEmpty())
-        {
+        if (message.npcs.isEmpty() || (Mappet.npcsToolOnlyOP.get() && !OpHelper.isPlayerOp(player)) || (Mappet.npcsToolOnlyCreative.get() && !player.capabilities.isCreativeMode)) {
             return;
         }
 

--- a/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcState.java
+++ b/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcState.java
@@ -1,9 +1,11 @@
 package mchorse.mappet.network.server.npc;
 
+import mchorse.mappet.Mappet;
 import mchorse.mappet.api.npcs.NpcState;
 import mchorse.mappet.entities.EntityNpc;
 import mchorse.mappet.network.common.npc.PacketNpcState;
 import mchorse.mclib.network.ServerMessageHandler;
+import mchorse.mclib.utils.OpHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 
@@ -12,6 +14,9 @@ public class ServerHandlerNpcState extends ServerMessageHandler<PacketNpcState>
     @Override
     public void run(EntityPlayerMP player, PacketNpcState message)
     {
+        if ((Mappet.npcsToolOnlyOP.get() && !OpHelper.isPlayerOp(player)) || (Mappet.npcsToolOnlyCreative.get() && !player.capabilities.isCreativeMode)) {
+            return;
+        }
         Entity npc = player.world.getEntityByID(message.entityId);
 
         if (npc instanceof EntityNpc)

--- a/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcTool.java
+++ b/src/main/java/mchorse/mappet/network/server/npc/ServerHandlerNpcTool.java
@@ -3,6 +3,7 @@ package mchorse.mappet.network.server.npc;
 import mchorse.mappet.Mappet;
 import mchorse.mappet.network.common.npc.PacketNpcTool;
 import mchorse.mclib.network.ServerMessageHandler;
+import mchorse.mclib.utils.OpHelper;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -12,6 +13,9 @@ public class ServerHandlerNpcTool extends ServerMessageHandler<PacketNpcTool>
     @Override
     public void run(EntityPlayerMP player, PacketNpcTool message)
     {
+        if ((Mappet.npcsToolOnlyOP.get() && !OpHelper.isPlayerOp(player)) || (Mappet.npcsToolOnlyCreative.get() && !player.capabilities.isCreativeMode)) {
+            return;
+        }
         ItemStack stack = player.getHeldItemMainhand();
 
         if (stack.getItem() == Mappet.npcTool)


### PR DESCRIPTION
### Summary
  Added server-side permission checks across NPC packet handlers to prevent unauthorized manipulation. Previously, `NpcState` could allow arbitrary code execution on the server if an NPC was present
### Changes
  Added Op/Creative check to `ServerHandlerNpcState`, `ServerHandlerNpcList`, and `ServerHandlerNpcTool`
  Added isRiding check to `ServerHandlerNpcJump`
### Security impact
  Severity: High for the `ServerHandlerNpcState` (prevents potential script injection)
  Other fixes: lowered-risk integrity/permission issues